### PR TITLE
Make the title a link to the running application

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-The Big Book of Acronyms (BBA)
+[The Big Book of Acronyms (BBA)](http://bigbookofacronyms.herokuapp.com/)
 ==============================
 
 This is a simple glossory of acronyms so you can add them very easily and quickly. It's built in Ruby on Rails and uses [Twitter Bootstrap](http://twitter.github.com/bootstrap) for it's presentation.


### PR DESCRIPTION
This repo is (currently) the first google result for the search "big book of acronyms." The application page is the fourth result, so it would be helpful to have a link from this repo to the actual application.