### PR TITLE
Redirect to /README.md of the acronyms repo

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,1 +1,1 @@
-<?php header('Location: https://github.com/ministryofjustice/acronyms'); ?>
+<?php header('Location: https://github.com/ministryofjustice/acronyms/blob/master/README.md'); ?>


### PR DESCRIPTION
The existing redirect to https://github.com/ministryofjustice/acronyms only shows you *part* of the README.md file (which contains the whole list of abbreviations). Github truncates the file, so that the last visible acronym is "PGD".

So, any users who want to look up an abbreviation which is alphabetically after PGD have to know to click on the link to view the whole file, and *then* do Cmd-F to search for the string they want to look up. This is a poor user experience.

This change redirects to a URL which displays the whole README.md file, all the way to 'xxx' (currently the last value), so users can immediately use Cmd-F to find the abbreviation they're interested in.

The downside of this change is that the page takes about 2 seconds longer to load, but IMO the usability benefit is worth it.